### PR TITLE
Use HTTPS for API endpoint

### DIFF
--- a/MMM-AirNow.js
+++ b/MMM-AirNow.js
@@ -19,7 +19,7 @@ Module.register('MMM-AirNow', {
 
         // Set up the local values, here we construct the request url to use
         this.loaded = false;
-        this.url = 'http://www.airnowapi.org/aq/observation/zipCode/current/?format=application/json&zipCode=' + this.config.zip_code + '&distance=25&API_KEY=' + this.config.api_key;
+        this.url = 'https://www.airnowapi.org/aq/observation/zipCode/current/?format=application/json&zipCode=' + this.config.zip_code + '&distance=25&API_KEY=' + this.config.api_key;
         this.location = '';
         this.result = null;
 


### PR DESCRIPTION
Enables HTTPS for AirNow API calls.

Tested against MagicMirror 2.9.0.